### PR TITLE
Configure access logging for gunicorn

### DIFF
--- a/app/run.sh
+++ b/app/run.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-gunicorn --reload app:app -b $(ip -4 a | awk '/inet.*eth0/{split($2, a, "/"); print a[1]}'):5678
+# BUGS:
+# 1.  Using 10.49 in the regex is a total hack.
+gunicorn \
+	--daemon \
+	--reload app:app \
+	-b $(ip -4 a | awk '/inet.*10.49/{split($2, a, "/"); print a[1]}'):5678 \
+	--access-logfile /home/mike/var/log/gunicorn/access.log


### PR DESCRIPTION
Add command line arguments to demonize and write access logs.